### PR TITLE
Remove AppVita from app review platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,6 @@
 
  - [Appliv](https://app-liv.jp/contact/review_request/ )：一个移动应用发现和评论网站，允许开发者提交他们的移动应用。
 
- - [AppVita](https://appvita.com/ )：专注于发现和推荐改善生活各个方面的基于网络的应用程序。自2006年成立以来，AppVita已经精选并评论了超过1600个应用程序。
-
  - [Appysmarts](https://www.appysmarts.com/suggest.php )：一个提供免费儿童应用程序和游戏的平台，适用于智能手机和平板电脑。开发者可以在该平台上提交他们开发的应用程序进行评估和审核，以便将其列入Appysmarts的数据库和新闻通讯中。
 
  - [ASR](https://www.activesearchresults.com/ )：一个独立的互联网搜索引擎，使用Active Search Results Page Ranking Technology（ASR Ranking）来对搜索结果进行排名。该搜索引擎采用了一种新的页面排名算法，允许搜索引擎将排名更高的搜索结果显示给网站所有者或推广者。[提交你的网站](https://www.activesearchresults.com/addwebsite.php )。


### PR DESCRIPTION
AppVita 自2006年成立以来，2015年之后就再也没有更新过，死了10年了，提交新的产品也没有任何回应。建议移除。谢谢。

<!--
 ### 每个渠道都有自己的特点

利用这些渠道，你就能：

- 把你的产品推销出去，让更多人知道。
- 找到你的目标用户，那些最有可能对你的产品感兴趣的人。
- 简化产品推广的过程，让你把更多时间花在开发牛掰的产品上。
- 找到你的第一个1000个用户。

-->

## Requirements

<!-- 这仅适用于新提交 -->
<!-- 请确保您的提交满足所有要求 -->

 * [ ] 可收录开发者的产品，包括移动应用、插件、桌面软件等
 * [ ] 可以是网站、目录、导航站、社区论坛、社群等
 * [ ] 必须是免费收录的
 * [ ] 提交的内容不在列表中
 * [ ] 服务有运营人员的联系方式和隐私政策
