### PR TITLE
新增 ZPlatform.ai 到海外AI导航网站

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,8 @@
  
  - [Free AI Tool](https://freeaitool.ai )：一个全面的AI在线导航网站，展示最新和最佳的人工智能工具，24小时内快速收录，[支持免费提交](https://freeaitool.ai/submit )。
  
+ - [ZPlatform.ai](https://zplatform.ai )：一个经过实测的AI工具与软件优惠目录，为每个收录的工具给出购买、观望或略过的评测建议，涵盖写作、SEO、设计、生产力等分类。
+ 
  [![Back to Top](assets/Back-To-Top.svg)](#目录)
 
 ####  📚海外目录站点


### PR DESCRIPTION
在「🛠️海外AI导航网站」分区新增一条 **ZPlatform.ai**。

ZPlatform.ai 是一个 AI 工具与软件优惠目录，对收录的工具进行实测，并给出「购买 / 观望 / 略过」的评测建议，按写作、SEO、设计、生产力等分类整理，与本分区的其他 AI 导航/目录站点性质一致。

- 沿用现有的 ` - [名称](网址)：描述` 格式
- 放置在该分区末尾
- 未重复收录

Thanks for maintaining this guide!