### PR TITLE
新增海外目录站点：SaaSCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,8 @@
  - [Domaining.in](http://domaining.in/ )：一个免费的目录网站，为用户提供了广泛的分类和主题，涵盖了各个领域的网站链接。
 
  - [Sitelike](https://www.sitelike.org/add-site )：一个用于查找与给定网站类似、替代或相关的网站。用户可以免费将自己的网站添加到[Sitelike](https://www.sitelike.org/add-site )，并通过该平台获得更多的曝光和访问机会。
+ - [SaaSCity](https://saascity.io/submit )：游戏化的 SaaS 目录，每个提交的产品会变成等距城市地图上的一栋建筑。免费收录，人工审核，通常 24 小时内通过。
+
 
  - [Submission Web Directory](https://www.submissionwebdirectory.com/ )：一个网站目录，按照相关类别列出网站，以帮助用户找到正在寻找的网站。
 


### PR DESCRIPTION
在「📚海外目录站点」中新增 **SaaSCity**。

- 网址：https://saascity.io
- 提交页：https://saascity.io/submit
- Ahrefs DR：46

游戏化的 SaaS 目录：每个提交的产品会变成等距城市地图上的一栋建筑。

## Requirements

 * [x] 可收录开发者的产品，包括移动应用、插件、桌面软件等
 * [x] 可以是网站、目录、导航站、社区论坛、社群等
 * [x] 必须是免费收录的 —— 免费收录，付费仅用于 dofollow 外链和地图展示位
 * [x] 提交的内容不在列表中
 * [x] 服务有运营人员的联系方式和隐私政策 —— https://saascity.io/privacy

人工审核，通常 24 小时内通过。